### PR TITLE
Fix comment typo in build config

### DIFF
--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -16,7 +16,7 @@ module.exports = function (eleventyConfig) {
     globals: ["filters"],
   });
 
-  // Instanciate the Vite plugin
+  // Instantiate the Vite plugin.
   eleventyConfig.addPlugin(EleventyVitePlugin, {
     viteOptions: {
       plugins: [


### PR DESCRIPTION
## Summary
- correct a typo in `eleventy.config.js` comment

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_683f494eb2d48321b4bd4a4c0526ef47